### PR TITLE
49/feat/campaign react/hoyeon

### DIFF
--- a/src/main/java/com/merge/final_project/campaign/campaigns/CampaignStatus.java
+++ b/src/main/java/com/merge/final_project/campaign/campaigns/CampaignStatus.java
@@ -1,6 +1,6 @@
 package com.merge.final_project.campaign.campaigns;
 
 public enum CampaignStatus {
-    // PENDING(관리자 승인 전), RECRUITING(관리자 승인 후 등록), ENDED(모집 종료), ACTIVE(활동중), SETTLED(정산완료된 날), COMPLETED(보고서를 낸 날), CANCELLED(중간에 취소된 날)
-    PENDING, RECRUITING, ACTIVE, ENDED, SETTLED, COMPLETED, CANCELLED
+    /* PENDING(대기중), APPROVED(승인됨), REJECTED(거절됨) */
+    PENDING, APPROVED, RECRUITING, ACTIVE, ENDED, SETTLED, COMPLETED, CANCELLED
 }

--- a/src/main/java/com/merge/final_project/campaign/campaigns/controller/CampaignController.java
+++ b/src/main/java/com/merge/final_project/campaign/campaigns/controller/CampaignController.java
@@ -4,6 +4,7 @@ import com.merge.final_project.campaign.campaigns.dto.CampaignBeneficiaryCheckRe
 import com.merge.final_project.campaign.campaigns.dto.CampaignDetailResponseDTO;
 import com.merge.final_project.campaign.campaigns.dto.CampaignFoundationCheckResponseDTO;
 import com.merge.final_project.campaign.campaigns.dto.CampaignListResponseDTO;
+import com.merge.final_project.campaign.campaigns.dto.CampaignRegisterResponseDTO;
 import com.merge.final_project.campaign.campaigns.dto.CampaignRequestDTO;
 import com.merge.final_project.campaign.campaigns.service.CampaignService;
 import lombok.RequiredArgsConstructor;
@@ -44,14 +45,13 @@ public class CampaignController {
     /* 신규 캠페인 등록 API: JSON 데이터(@RequestPart dto)와 이미지 파일들을 동시에 처리하는 multipart/form-data 방식 */
     @ResponseBody
     @PostMapping(value = "/register", consumes = {"multipart/form-data"})
-    public ResponseEntity<String> register(
+    public ResponseEntity<CampaignRegisterResponseDTO> register(
             @RequestPart("dto") CampaignRequestDTO dto,
             @RequestPart("imageFile") MultipartFile imageFile,
             @RequestPart(value = "detailImageFiles", required = false) List<MultipartFile> detailImageFiles,
             @RequestParam("foundationNo") Long foundationNo
     ) {
-        campaignService.registerCampaign(dto, imageFile, detailImageFiles, foundationNo);
-        return ResponseEntity.ok("캠페인 등록 요청 완료");
+        return ResponseEntity.ok(campaignService.registerCampaign(dto, imageFile, detailImageFiles, foundationNo));
     }
 
     /* 수혜자 확인: 입력된 엔트리 코드가 유효한 수혜자인지 검증함 */
@@ -86,5 +86,11 @@ public class CampaignController {
         CampaignDetailResponseDTO campaign = campaignService.getCampaignDetail(campaignNo);
         model.addAttribute("campaign", campaign);
         return "campaign/detail";
+    }
+
+    @ResponseBody
+    @GetMapping("/{campaignNo}/detail")
+    public ResponseEntity<CampaignDetailResponseDTO> getCampaignDetail(@PathVariable Long campaignNo) {
+        return ResponseEntity.ok(campaignService.getCampaignDetail(campaignNo));
     }
 }

--- a/src/main/java/com/merge/final_project/campaign/campaigns/dto/CampaignRegisterResponseDTO.java
+++ b/src/main/java/com/merge/final_project/campaign/campaigns/dto/CampaignRegisterResponseDTO.java
@@ -1,0 +1,14 @@
+package com.merge.final_project.campaign.campaigns.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CampaignRegisterResponseDTO {
+    private Long campaignNo;
+    private Long foundationNo;
+    private String approvalStatus;
+    private String campaignStatus;
+    private String message;
+}

--- a/src/main/java/com/merge/final_project/campaign/campaigns/service/CampaignService.java
+++ b/src/main/java/com/merge/final_project/campaign/campaigns/service/CampaignService.java
@@ -4,13 +4,14 @@ import com.merge.final_project.campaign.campaigns.dto.CampaignBeneficiaryCheckRe
 import com.merge.final_project.campaign.campaigns.dto.CampaignDetailResponseDTO;
 import com.merge.final_project.campaign.campaigns.dto.CampaignFoundationCheckResponseDTO;
 import com.merge.final_project.campaign.campaigns.dto.CampaignListResponseDTO;
+import com.merge.final_project.campaign.campaigns.dto.CampaignRegisterResponseDTO;
 import com.merge.final_project.campaign.campaigns.dto.CampaignRequestDTO;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface CampaignService {
-    void registerCampaign(
+    CampaignRegisterResponseDTO registerCampaign(
             CampaignRequestDTO requestDto,
             MultipartFile imageFile,
             List<MultipartFile> detailImageFiles,

--- a/src/main/java/com/merge/final_project/campaign/campaigns/service/CampaignServiceImpl.java
+++ b/src/main/java/com/merge/final_project/campaign/campaigns/service/CampaignServiceImpl.java
@@ -51,12 +51,13 @@ public class CampaignServiceImpl implements CampaignService {
     private static final String REPRESENTATIVE_IMAGE_PURPOSE = "REPRESENTATIVE";
     private static final String DETAIL_IMAGE_PURPOSE = "DETAIL";
     private static final List<CampaignStatus> LIST_VISIBLE_STATUSES = List.of(
-        CampaignStatus.RECRUITING,
-        CampaignStatus.ACTIVE,
-        CampaignStatus.ENDED,
-        CampaignStatus.SETTLED,
-        CampaignStatus.COMPLETED,
-        CampaignStatus.CANCELLED
+            CampaignStatus.APPROVED,
+            CampaignStatus.RECRUITING,
+            CampaignStatus.ACTIVE,
+            CampaignStatus.ENDED,
+            CampaignStatus.SETTLED,
+            CampaignStatus.COMPLETED,
+            CampaignStatus.CANCELLED
     );
 
     private final FoundationRepository foundationRepository;
@@ -66,7 +67,7 @@ public class CampaignServiceImpl implements CampaignService {
     private final UsePlanRepository usePlanRepository;
     private final ImageRepository imageRepository;
     private final FileService fileService;
-    private final ApplicationEventPublisher eventPublisher; // [가빈] SSE 이벤트 발행용
+    private final ApplicationEventPublisher eventPublisher; // SSE 이벤트 발행을 위한 주입
 
     @Override
     @Transactional
@@ -76,20 +77,20 @@ public class CampaignServiceImpl implements CampaignService {
         }
 
         Foundation foundation = foundationRepository.findById(foundationNo)
-            .orElseThrow(() -> new IllegalArgumentException("해당 재단 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 재단 정보를 찾을 수 없습니다."));
 
         Beneficiary beneficiary = beneficiaryRepository.findByEntryCode(dto.getEntryCode())
-            .orElseThrow(() -> new IllegalArgumentException("Invalid beneficiary entry code."));
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 수혜자 코드입니다."));
 
         List<String> walletAddresses = Stream.of(
-            foundation.getCampaignWallet1(),
-            foundation.getCampaignWallet2(),
-            foundation.getCampaignWallet3()
+                foundation.getCampaignWallet1(),
+                foundation.getCampaignWallet2(),
+                foundation.getCampaignWallet3()
         ).filter(Objects::nonNull).toList();
 
         Wallet availableWallet = walletRepository
-            .findFirstByWalletAddressInAndStatus(walletAddresses, WalletStatus.INACTIVE)
-            .orElseThrow(() -> new IllegalStateException("사용 가능한 지갑이 없습니다."));
+                .findFirstByWalletAddressInAndStatus(walletAddresses, WalletStatus.INACTIVE)
+                .orElseThrow(() -> new IllegalStateException("사용 가능한 지갑이 없습니다."));
 
         Campaign campaign = dto.toEntity();
         campaign.setFoundationNo(foundationNo);
@@ -115,19 +116,19 @@ public class CampaignServiceImpl implements CampaignService {
         availableWallet.changeStatus(WalletStatus.ACTIVE);
         walletRepository.save(availableWallet);
 
-        // [가빈] 관리자에게 캠페인 승인 요청 SSE 알림
+        // 관리자에게 캠페인 승인 요청 SSE 알림 발행
         eventPublisher.publishEvent(new ApprovalRequestEvent(
                 TargetType.CAMPAIGN,
                 savedCampaign.getCampaignNo(),
                 savedCampaign.getTitle() + " 캠페인 승인 요청"));
 
         return CampaignRegisterResponseDTO.builder()
-            .campaignNo(savedCampaign.getCampaignNo())
-            .foundationNo(savedCampaign.getFoundationNo())
-            .approvalStatus(savedCampaign.getApprovalStatus() == null ? null : savedCampaign.getApprovalStatus().name())
-            .campaignStatus(savedCampaign.getCampaignStatus() == null ? null : savedCampaign.getCampaignStatus().name())
-            .message("캠페인 등록 요청 완료")
-            .build();
+                .campaignNo(savedCampaign.getCampaignNo())
+                .foundationNo(savedCampaign.getFoundationNo())
+                .approvalStatus(savedCampaign.getApprovalStatus() == null ? null : savedCampaign.getApprovalStatus().name())
+                .campaignStatus(savedCampaign.getCampaignStatus() == null ? null : savedCampaign.getCampaignStatus().name())
+                .message("캠페인 등록 요청 완료")
+                .build();
     }
 
     @Override
@@ -137,21 +138,21 @@ public class CampaignServiceImpl implements CampaignService {
 
         if ("participation".equalsIgnoreCase(sort)) {
             comparator = Comparator
-                .comparing((Campaign campaign) -> campaign.getCurrentAmount() == null ? 0L : campaign.getCurrentAmount())
-                .reversed()
-                .thenComparing(Campaign::getCampaignNo, Comparator.reverseOrder());
+                    .comparing((Campaign campaign) -> campaign.getCurrentAmount() == null ? 0L : campaign.getCurrentAmount())
+                    .reversed()
+                    .thenComparing(Campaign::getCampaignNo, Comparator.reverseOrder());
         } else {
             comparator = Comparator
-                .comparing(Campaign::getEndAt, Comparator.nullsLast(Comparator.naturalOrder()))
-                .thenComparing(Campaign::getCampaignNo, Comparator.reverseOrder());
+                    .comparing(Campaign::getEndAt, Comparator.nullsLast(Comparator.naturalOrder()))
+                    .thenComparing(Campaign::getCampaignNo, Comparator.reverseOrder());
         }
 
         List<Campaign> campaigns = campaignRepository.findAll().stream()
-            .filter(campaign -> campaign.getCampaignStatus() != null && LIST_VISIBLE_STATUSES.contains(campaign.getCampaignStatus()))
-            .filter(campaign -> matchesCategory(campaign, category))
-            .filter(campaign -> matchesKeyword(campaign, searchType, keyword))
-            .sorted(comparator)
-            .toList();
+                .filter(campaign -> campaign.getCampaignStatus() != null && LIST_VISIBLE_STATUSES.contains(campaign.getCampaignStatus()))
+                .filter(campaign -> matchesCategory(campaign, category))
+                .filter(campaign -> matchesKeyword(campaign, searchType, keyword))
+                .sorted(comparator)
+                .toList();
 
         return toCampaignListResponse(campaigns);
     }
@@ -160,115 +161,115 @@ public class CampaignServiceImpl implements CampaignService {
     @Transactional(readOnly = true)
     public CampaignDetailResponseDTO getCampaignDetail(Long campaignNo) {
         Campaign campaign = campaignRepository.findByCampaignNoAndApprovalStatus(campaignNo, ApprovalStatus.APPROVED)
-            .orElseThrow(() -> new IllegalArgumentException("승인된 캠페인을 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("승인된 캠페인을 찾을 수 없습니다."));
 
         Foundation foundation = foundationRepository.findByFoundationNo(campaign.getFoundationNo())
-            .orElseThrow(() -> new IllegalArgumentException("기부 단체 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("기부 단체 정보를 찾을 수 없습니다."));
 
         long currentAmount = campaign.getCurrentAmount() == null ? 0L : campaign.getCurrentAmount();
         long targetAmount = campaign.getTargetAmount() == null ? 0L : campaign.getTargetAmount();
         CampaignStatus campaignStatus = campaign.getCampaignStatus() == null ? CampaignStatus.PENDING : campaign.getCampaignStatus();
         String walletAddress = campaign.getWalletNo() == null ? null : walletRepository.findById(campaign.getWalletNo())
-            .map(Wallet::getWalletAddress)
-            .orElse(null);
+                .map(Wallet::getWalletAddress)
+                .orElse(null);
 
         List<Image> campaignImages = imageRepository.findByTargetNameAndTargetNo(CAMPAIGN_IMAGE_TARGET_NAME, campaignNo)
-            .stream()
-            .sorted(Comparator.comparing(Image::getCreatedAt))
-            .toList();
+                .stream()
+                .sorted(Comparator.comparing(Image::getCreatedAt))
+                .toList();
 
         String representativeImagePath = campaignImages.stream()
-            .filter(image -> REPRESENTATIVE_IMAGE_PURPOSE.equals(image.getPurpose()))
-            .map(Image::getImgPath)
-            .findFirst()
-            .orElse(campaign.getImagePath());
+                .filter(image -> REPRESENTATIVE_IMAGE_PURPOSE.equals(image.getPurpose()))
+                .map(Image::getImgPath)
+                .findFirst()
+                .orElse(campaign.getImagePath());
 
         List<String> detailImagePaths = campaignImages.stream()
-            .filter(image -> DETAIL_IMAGE_PURPOSE.equals(image.getPurpose()))
-            .map(Image::getImgPath)
-            .toList();
+                .filter(image -> DETAIL_IMAGE_PURPOSE.equals(image.getPurpose()))
+                .map(Image::getImgPath)
+                .toList();
 
         List<CampaignDetailResponseDTO.UsePlanSummary> usePlans = usePlanRepository.findByCampaignNoOrderByUsePlanNoAsc(campaignNo)
-            .stream()
-            .map(plan -> CampaignDetailResponseDTO.UsePlanSummary.builder()
-                .usePlanNo(plan.getUsePlanNo())
-                .planContent(plan.getPlanContent())
-                .planAmount(plan.getPlanAmount())
-                .build())
-            .toList();
+                .stream()
+                .map(plan -> CampaignDetailResponseDTO.UsePlanSummary.builder()
+                        .usePlanNo(plan.getUsePlanNo())
+                        .planContent(plan.getPlanContent())
+                        .planAmount(plan.getPlanAmount())
+                        .build())
+                .toList();
 
         return CampaignDetailResponseDTO.builder()
-            .campaignNo(campaign.getCampaignNo())
-            .title(campaign.getTitle())
-            .description(campaign.getDescription())
-            .category(campaign.getCategory() == null ? null : campaign.getCategory().getLabel())
-            .approvalStatus(campaign.getApprovalStatus() == null ? ApprovalStatus.PENDING.name() : campaign.getApprovalStatus().name())
-            .campaignStatus(campaignStatus.name())
-            .campaignStatusLabel(toCampaignStatusLabel(campaignStatus))
-            .historyTitle(toHistoryTitle(campaignStatus))
-            .historyDescription(toHistoryDescription(campaignStatus))
-            .targetAmount(targetAmount)
-            .currentAmount(currentAmount)
-            .progressPercent(calculateProgressPercent(currentAmount, targetAmount))
-            .remainingAmount(calculateRemainingAmount(targetAmount, currentAmount))
-            .daysLeft(calculateDaysLeft(campaign.getEndAt()))
-            .startAt(campaign.getStartAt())
-            .endAt(campaign.getEndAt())
-            .usageStartAt(campaign.getUsageStartAt())
-            .usageEndAt(campaign.getUsageEndAt())
-            .walletAddress(walletAddress)
-            .representativeImagePath(representativeImagePath)
-            .detailImagePaths(detailImagePaths)
-            .foundation(CampaignDetailResponseDTO.FoundationSummary.builder()
-                .foundationNo(foundation.getFoundationNo())
-                .foundationName(foundation.getFoundationName())
-                .description(foundation.getDescription())
-                .profilePath(foundation.getProfilePath())
-                .build())
-            .usePlans(usePlans)
-            .build();
+                .campaignNo(campaign.getCampaignNo())
+                .title(campaign.getTitle())
+                .description(campaign.getDescription())
+                .category(campaign.getCategory() == null ? null : campaign.getCategory().getLabel())
+                .approvalStatus(campaign.getApprovalStatus() == null ? ApprovalStatus.PENDING.name() : campaign.getApprovalStatus().name())
+                .campaignStatus(campaignStatus.name())
+                .campaignStatusLabel(toCampaignStatusLabel(campaignStatus))
+                .historyTitle(toHistoryTitle(campaignStatus))
+                .historyDescription(toHistoryDescription(campaignStatus))
+                .targetAmount(targetAmount)
+                .currentAmount(currentAmount)
+                .progressPercent(calculateProgressPercent(currentAmount, targetAmount))
+                .remainingAmount(calculateRemainingAmount(targetAmount, currentAmount))
+                .daysLeft(calculateDaysLeft(campaign.getEndAt()))
+                .startAt(campaign.getStartAt())
+                .endAt(campaign.getEndAt())
+                .usageStartAt(campaign.getUsageStartAt())
+                .usageEndAt(campaign.getUsageEndAt())
+                .walletAddress(walletAddress)
+                .representativeImagePath(representativeImagePath)
+                .detailImagePaths(detailImagePaths)
+                .foundation(CampaignDetailResponseDTO.FoundationSummary.builder()
+                        .foundationNo(foundation.getFoundationNo())
+                        .foundationName(foundation.getFoundationName())
+                        .description(foundation.getDescription())
+                        .profilePath(foundation.getProfilePath())
+                        .build())
+                .usePlans(usePlans)
+                .build();
     }
 
     @Override
     @Transactional(readOnly = true)
     public CampaignBeneficiaryCheckResponseDTO checkBeneficiaryByEntryCode(String entryCode) {
         return beneficiaryRepository.findByEntryCode(entryCode)
-            .map(beneficiary -> CampaignBeneficiaryCheckResponseDTO.builder()
-                .valid(true)
-                .beneficiaryNo(beneficiary.getBeneficiaryNo())
-                .entryCode(beneficiary.getEntryCode())
-                .name(beneficiary.getName())
-                .beneficiaryType(beneficiary.getBeneficiaryType() == null ? null : beneficiary.getBeneficiaryType().name())
-                .message("수혜자 정보를 확인했습니다.")
-                .build())
-            .orElseGet(() -> CampaignBeneficiaryCheckResponseDTO.builder()
-                .valid(false)
-                .entryCode(entryCode)
-                .message("일치하는 수혜자 entry code가 없습니다.")
-                .build());
+                .map(beneficiary -> CampaignBeneficiaryCheckResponseDTO.builder()
+                        .valid(true)
+                        .beneficiaryNo(beneficiary.getBeneficiaryNo())
+                        .entryCode(beneficiary.getEntryCode())
+                        .name(beneficiary.getName())
+                        .beneficiaryType(beneficiary.getBeneficiaryType() == null ? null : beneficiary.getBeneficiaryType().name())
+                        .message("수혜자 정보를 확인했습니다.")
+                        .build())
+                .orElseGet(() -> CampaignBeneficiaryCheckResponseDTO.builder()
+                        .valid(false)
+                        .entryCode(entryCode)
+                        .message("일치하는 수혜자 코드가 없습니다.")
+                        .build());
     }
 
     @Override
     @Transactional(readOnly = true)
     public CampaignFoundationCheckResponseDTO checkFoundationWalletStatus(Long foundationNo) {
         Foundation foundation = foundationRepository.findByFoundationNo(foundationNo)
-            .orElseThrow(() -> new IllegalArgumentException("기부 단체 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("기부 단체 정보를 찾을 수 없습니다."));
 
         List<CampaignFoundationCheckResponseDTO.WalletStatusItem> wallets = List.of(
-            toWalletStatusItem("지갑 1", foundation.getCampaignWallet1()),
-            toWalletStatusItem("지갑 2", foundation.getCampaignWallet2()),
-            toWalletStatusItem("지갑 3", foundation.getCampaignWallet3())
+                toWalletStatusItem("지갑 1", foundation.getCampaignWallet1()),
+                toWalletStatusItem("지갑 2", foundation.getCampaignWallet2()),
+                toWalletStatusItem("지갑 3", foundation.getCampaignWallet3())
         );
 
         boolean hasAvailableWallet = wallets.stream().anyMatch(CampaignFoundationCheckResponseDTO.WalletStatusItem::isAvailable);
 
         return CampaignFoundationCheckResponseDTO.builder()
-            .foundationNo(foundation.getFoundationNo())
-            .foundationName(foundation.getFoundationName())
-            .hasAvailableWallet(hasAvailableWallet)
-            .message(hasAvailableWallet ? "사용 가능한 캠페인 지갑이 있습니다." : "사용 가능한 캠페인 지갑이 없습니다.")
-            .wallets(wallets)
-            .build();
+                .foundationNo(foundation.getFoundationNo())
+                .foundationName(foundation.getFoundationName())
+                .hasAvailableWallet(hasAvailableWallet)
+                .message(hasAvailableWallet ? "사용 가능한 캠페인 지갑이 있습니다." : "사용 가능한 캠페인 지갑이 없습니다.")
+                .wallets(wallets)
+                .build();
     }
 
     private List<CampaignListResponseDTO> toCampaignListResponse(List<Campaign> campaigns) {
@@ -277,38 +278,38 @@ public class CampaignServiceImpl implements CampaignService {
         }
 
         Map<Long, String> imagePathByCampaignNo = campaigns.stream()
-            .collect(Collectors.toMap(
-                Campaign::getCampaignNo,
-                campaign -> imageRepository.findByTargetNameAndTargetNo(
-                        CAMPAIGN_IMAGE_TARGET_NAME,
-                        campaign.getCampaignNo()
-                    ).stream()
-                    .filter(image -> REPRESENTATIVE_IMAGE_PURPOSE.equals(image.getPurpose()))
-                    .sorted(Comparator.comparing(Image::getCreatedAt).reversed())
-                    .map(Image::getImgPath)
-                    .findFirst()
-                    .orElse(campaign.getImagePath() == null ? "" : campaign.getImagePath())
-            ));
+                .collect(Collectors.toMap(
+                        Campaign::getCampaignNo,
+                        campaign -> imageRepository.findByTargetNameAndTargetNo(
+                                        CAMPAIGN_IMAGE_TARGET_NAME,
+                                        campaign.getCampaignNo()
+                                ).stream()
+                                .filter(image -> REPRESENTATIVE_IMAGE_PURPOSE.equals(image.getPurpose()))
+                                .sorted(Comparator.comparing(Image::getCreatedAt).reversed())
+                                .map(Image::getImgPath)
+                                .findFirst()
+                                .orElse(campaign.getImagePath() == null ? "" : campaign.getImagePath())
+                ));
 
         return campaigns.stream()
-            .map(campaign -> CampaignListResponseDTO.builder()
-                .campaignNo(campaign.getCampaignNo())
-                .foundationNo(campaign.getFoundationNo())
-                .imagePath(imagePathByCampaignNo.get(campaign.getCampaignNo()))
-                .title(campaign.getTitle())
-                .foundationName(
-                    campaign.getFoundationNo() == null
-                        ? null
-                        : foundationRepository.findByFoundationNo(campaign.getFoundationNo())
-                            .map(Foundation::getFoundationName)
-                            .orElse(null)
-                )
-                .targetAmount(campaign.getTargetAmount())
-                .currentAmount(campaign.getCurrentAmount())
-                .category(toCampaignCategoryLabel(campaign.getCategory()))
-                .endAt(campaign.getEndAt())
-                .build())
-            .toList();
+                .map(campaign -> CampaignListResponseDTO.builder()
+                        .campaignNo(campaign.getCampaignNo())
+                        .foundationNo(campaign.getFoundationNo())
+                        .imagePath(imagePathByCampaignNo.get(campaign.getCampaignNo()))
+                        .title(campaign.getTitle())
+                        .foundationName(
+                                campaign.getFoundationNo() == null
+                                        ? null
+                                        : foundationRepository.findByFoundationNo(campaign.getFoundationNo())
+                                        .map(Foundation::getFoundationName)
+                                        .orElse(null)
+                        )
+                        .targetAmount(campaign.getTargetAmount())
+                        .currentAmount(campaign.getCurrentAmount())
+                        .category(toCampaignCategoryLabel(campaign.getCategory()))
+                        .endAt(campaign.getEndAt())
+                        .build())
+                .toList();
     }
 
     private boolean matchesCategory(Campaign campaign, String category) {
@@ -333,8 +334,8 @@ public class CampaignServiceImpl implements CampaignService {
 
         if ("foundation".equalsIgnoreCase(searchType)) {
             String foundationName = campaign.getFoundationNo() == null
-                ? null
-                : foundationRepository.findByFoundationNo(campaign.getFoundationNo())
+                    ? null
+                    : foundationRepository.findByFoundationNo(campaign.getFoundationNo())
                     .map(Foundation::getFoundationName)
                     .orElse(null);
             return foundationName != null && foundationName.toLowerCase().contains(normalizedKeyword);
@@ -350,7 +351,7 @@ public class CampaignServiceImpl implements CampaignService {
         }
 
         return switch (category) {
-            case CHILD_YOUTH -> "아동/청소년";
+            case CHILD_YOUTH -> "아동 및 청소년";
             case SENIOR -> "어르신";
             case DISABLED -> "장애인";
             case ANIMAL -> "동물";
@@ -379,39 +380,39 @@ public class CampaignServiceImpl implements CampaignService {
             String filePath = fileService.getFilePath(storedName);
 
             imageRepository.save(Image.builder()
-                .imgPath(filePath)
-                .imgOrgName(imageFile.getOriginalFilename())
-                .imgStoredName(storedName)
-                .targetName(CAMPAIGN_IMAGE_TARGET_NAME)
-                .targetNo(campaignNo)
-                .createdAt(LocalDateTime.now())
-                .purpose(purpose)
-                .build());
+                    .imgPath(filePath)
+                    .imgOrgName(imageFile.getOriginalFilename())
+                    .imgStoredName(storedName)
+                    .targetName(CAMPAIGN_IMAGE_TARGET_NAME)
+                    .targetNo(campaignNo)
+                    .createdAt(LocalDateTime.now())
+                    .purpose(purpose)
+                    .build());
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("이미지 저장 중 오류가 발생했습니다.", e);
         }
     }
 
     private CampaignFoundationCheckResponseDTO.WalletStatusItem toWalletStatusItem(String walletLabel, String walletAddress) {
         if (walletAddress == null || walletAddress.isBlank()) {
             return CampaignFoundationCheckResponseDTO.WalletStatusItem.builder()
-                .walletLabel(walletLabel)
-                .walletAddress(null)
-                .status("NOT_REGISTERED")
-                .available(false)
-                .build();
+                    .walletLabel(walletLabel)
+                    .walletAddress(null)
+                    .status("미등록")
+                    .available(false)
+                    .build();
         }
 
         Optional<Wallet> wallet = walletRepository.findByWalletAddress(walletAddress);
-        String status = wallet.map(value -> value.getStatus() == null ? "UNKNOWN" : value.getStatus().name()).orElse("NOT_FOUND");
+        String status = wallet.map(value -> value.getStatus() == null ? "상태불명" : value.getStatus().name()).orElse("찾을수없음");
         boolean available = wallet.map(value -> WalletStatus.INACTIVE.equals(value.getStatus())).orElse(false);
 
         return CampaignFoundationCheckResponseDTO.WalletStatusItem.builder()
-            .walletLabel(walletLabel)
-            .walletAddress(walletAddress)
-            .status(status)
-            .available(available)
-            .build();
+                .walletLabel(walletLabel)
+                .walletAddress(walletAddress)
+                .status(status)
+                .available(available)
+                .build();
     }
 
     private int calculateProgressPercent(Long currentAmount, Long targetAmount) {
@@ -444,37 +445,37 @@ public class CampaignServiceImpl implements CampaignService {
 
     private String toCampaignStatusLabel(CampaignStatus campaignStatus) {
         return switch (campaignStatus) {
-            case PENDING -> "승인 대기";
-            case RECRUITING -> "모금 준비 중";
-            case ACTIVE -> "나눔 진행 중";
-            case ENDED -> "정산 준비 중";
+            case PENDING -> "승인 대기중";
+            case APPROVED, RECRUITING -> "모집중";
+            case ACTIVE -> "진행중";
+            case ENDED -> "모집 종료";
             case SETTLED -> "정산 완료";
-            case COMPLETED -> "나눔 완료";
-            case CANCELLED -> "나눔 취소";
+            case COMPLETED -> "캠페인 종료";
+            case CANCELLED -> "취소됨";
         };
     }
 
     private String toHistoryTitle(CampaignStatus campaignStatus) {
         return switch (campaignStatus) {
-            case PENDING -> "캠페인 승인 대기";
-            case RECRUITING -> "모금 준비 중";
-            case ACTIVE -> "나눔 진행 중";
-            case ENDED -> "정산 준비 중";
-            case SETTLED -> "정산 완료";
-            case COMPLETED -> "나눔 완료";
-            case CANCELLED -> "캠페인 취소";
+            case PENDING -> "검토 중인 캠페인";
+            case APPROVED, RECRUITING -> "참여 가능한 캠페인";
+            case ACTIVE -> "기부금이 전달된 캠페인";
+            case ENDED -> "모집이 완료된 캠페인";
+            case SETTLED -> "정산이 보고된 캠페인";
+            case COMPLETED -> "모든 일정이 종료된 캠페인";
+            case CANCELLED -> "중단된 캠페인";
         };
     }
 
     private String toHistoryDescription(CampaignStatus campaignStatus) {
         return switch (campaignStatus) {
-            case PENDING -> "캠페인이 승인 대기 상태입니다. 운영진 검토가 끝나면 모금 일정이 공개됩니다.";
-            case RECRUITING -> "모금 시작 전 준비 단계입니다. 공개 일정이 시작되면 상세 내역이 순차적으로 반영됩니다.";
-            case ACTIVE -> "현재 모금이 진행 중이거나 정산 준비 단계에 있습니다. 정산이 완료되면 상세 내역이 여기에 표시됩니다.";
-            case ENDED -> "모금은 종료되었으며 정산을 준비하고 있습니다. 정산이 확정되면 나눔 내역을 확인할 수 있습니다.";
-            case SETTLED -> "정산이 완료되었습니다. 최종 보고와 사용 결과가 정리되면 이 영역에서 확인할 수 있습니다.";
-            case COMPLETED -> "나눔과 보고가 모두 완료된 캠페인입니다. 최종 집행 결과가 반영된 상태입니다.";
-            case CANCELLED -> "캠페인이 취소되었습니다. 진행 사유와 상태는 운영 정책에 따라 별도로 안내됩니다.";
+            case PENDING -> "관리자가 캠페인을 검토하고 있습니다.";
+            case APPROVED, RECRUITING -> "기부 참여가 활발히 이루어지고 있습니다.";
+            case ACTIVE -> "목표 금액이 달성되어 기부금이 수혜자에게 전달되었습니다.";
+            case ENDED -> "모집 기간이 종료되어 정산을 준비 중입니다.";
+            case SETTLED -> "기부금 사용 내역이 투명하게 공개되었습니다.";
+            case COMPLETED -> "성공적으로 캠페인이 마무리되었습니다.";
+            case CANCELLED -> "부득이한 사정으로 캠페인이 취소되었습니다.";
         };
     }
 }

--- a/src/main/java/com/merge/final_project/campaign/campaigns/service/CampaignServiceImpl.java
+++ b/src/main/java/com/merge/final_project/campaign/campaigns/service/CampaignServiceImpl.java
@@ -3,12 +3,13 @@ package com.merge.final_project.campaign.campaigns.service;
 import com.merge.final_project.admin.adminlog.TargetType;
 import com.merge.final_project.admin.sse.ApprovalRequestEvent;
 import com.merge.final_project.campaign.campaigns.ApprovalStatus;
-import com.merge.final_project.campaign.campaigns.CampaignStatus;
 import com.merge.final_project.campaign.campaigns.CampaignCategory;
+import com.merge.final_project.campaign.campaigns.CampaignStatus;
 import com.merge.final_project.campaign.campaigns.dto.CampaignBeneficiaryCheckResponseDTO;
 import com.merge.final_project.campaign.campaigns.dto.CampaignDetailResponseDTO;
 import com.merge.final_project.campaign.campaigns.dto.CampaignFoundationCheckResponseDTO;
 import com.merge.final_project.campaign.campaigns.dto.CampaignListResponseDTO;
+import com.merge.final_project.campaign.campaigns.dto.CampaignRegisterResponseDTO;
 import com.merge.final_project.campaign.campaigns.dto.CampaignRequestDTO;
 import com.merge.final_project.campaign.campaigns.entity.Campaign;
 import com.merge.final_project.campaign.campaigns.repository.CampaignRepository;
@@ -69,13 +70,13 @@ public class CampaignServiceImpl implements CampaignService {
 
     @Override
     @Transactional
-    public void registerCampaign(CampaignRequestDTO dto, MultipartFile imageFile, List<MultipartFile> detailImageFiles, Long foundationNo) {
+    public CampaignRegisterResponseDTO registerCampaign(CampaignRequestDTO dto, MultipartFile imageFile, List<MultipartFile> detailImageFiles, Long foundationNo) {
         if (imageFile == null || imageFile.isEmpty()) {
             throw new IllegalArgumentException("대표 이미지는 필수입니다.");
         }
 
         Foundation foundation = foundationRepository.findById(foundationNo)
-            .orElseThrow(() -> new IllegalArgumentException("?? ??? ?? ? ????."));
+            .orElseThrow(() -> new IllegalArgumentException("해당 재단 정보를 찾을 수 없습니다."));
 
         Beneficiary beneficiary = beneficiaryRepository.findByEntryCode(dto.getEntryCode())
             .orElseThrow(() -> new IllegalArgumentException("Invalid beneficiary entry code."));
@@ -88,7 +89,7 @@ public class CampaignServiceImpl implements CampaignService {
 
         Wallet availableWallet = walletRepository
             .findFirstByWalletAddressInAndStatus(walletAddresses, WalletStatus.INACTIVE)
-            .orElseThrow(() -> new IllegalStateException("?? ??? ??? ????."));
+            .orElseThrow(() -> new IllegalStateException("사용 가능한 지갑이 없습니다."));
 
         Campaign campaign = dto.toEntity();
         campaign.setFoundationNo(foundationNo);
@@ -119,6 +120,14 @@ public class CampaignServiceImpl implements CampaignService {
                 TargetType.CAMPAIGN,
                 savedCampaign.getCampaignNo(),
                 savedCampaign.getTitle() + " 캠페인 승인 요청"));
+
+        return CampaignRegisterResponseDTO.builder()
+            .campaignNo(savedCampaign.getCampaignNo())
+            .foundationNo(savedCampaign.getFoundationNo())
+            .approvalStatus(savedCampaign.getApprovalStatus() == null ? null : savedCampaign.getApprovalStatus().name())
+            .campaignStatus(savedCampaign.getCampaignStatus() == null ? null : savedCampaign.getCampaignStatus().name())
+            .message("캠페인 등록 요청 완료")
+            .build();
     }
 
     @Override

--- a/src/main/java/com/merge/final_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/merge/final_project/global/config/SecurityConfig.java
@@ -116,7 +116,8 @@ public class SecurityConfig {
                                 "/api/foundation/login",     // 로그인
                                 "/api/foundation/logout",     // 로그아웃 (토큰 만료 후에도 호출 가능해야 함),
                                 "/api/foundation/campaigns/*",   // 캠페인
-                                "/api/foundation/campaigns"   // 캠페인
+                                "/api/foundation/campaigns",   // 캠페인
+                                "/api/foundation/campaigns/*/detail"   // 캠페인
                         ).permitAll()
                         // 그 외 단체 전용 기능은 ROLE_FOUNDATION 필요
                         .anyRequest().hasAuthority("ROLE_FOUNDATION")

--- a/src/main/java/com/merge/final_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/merge/final_project/global/config/SecurityConfig.java
@@ -27,19 +27,23 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
+    /**
+     * 비밀번호 인코더 빈.
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    /**
+     * 스프링 시큐리티 AuthenticationManager 주입용 빈.
+     */
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
         return authConfig.getAuthenticationManager();
     }
 
-    /**
-     * 1. 관리자 전용 필터 체인 (/admin/**)
-     */
+    //관리자
     @Order(1)
     @Bean
     public SecurityFilterChain adminFilterChain(HttpSecurity http, AdminJwtFilter adminJwtFilter) throws Exception {
@@ -62,23 +66,21 @@ public class SecurityConfig {
         return http.build();
     }
 
-    /**
-     * 2. 수혜자 및 리액트 전용 API 필터 체인
-     */
+    // 수혜자
     @Order(2)
     @Bean
     public SecurityFilterChain beneficiaryFilterChain(HttpSecurity http, JwtFilter jwtFilter) throws Exception {
         http
-                .securityMatcher("/api/beneficiary/**", "/finalReport/**", "/api/v1/**")
+                .securityMatcher("/api/beneficiary/**", "/finalReport/**") // 수혜자 전용 경로 지정
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        // 수혜자 로그인/회원가입은 공개 (v1 포함)
+                        // 수혜자 로그인/회원가입은 인증 없이 접근 가능
                         .requestMatchers("/api/beneficiary/signup", "/api/beneficiary/signin").permitAll()
-                        .requestMatchers("/api/v1/beneficiary/signup", "/api/v1/beneficiary/signin").permitAll()
-                        // 그 외 수혜자/보고서 관련은 인증 필요
+
+                        // 그 외 보고서 작성 등은 모두 인증 필요
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex
@@ -96,9 +98,7 @@ public class SecurityConfig {
         return http.build();
     }
 
-    /**
-     * 3. 기부단체 전용 필터 체인 (/api/foundation/**)
-     */
+    // 기부단체
     @Order(3)
     @Bean
     public SecurityFilterChain foundationFilterChain(HttpSecurity http, JwtFilter jwtFilter) throws Exception {
@@ -119,6 +119,7 @@ public class SecurityConfig {
                                 "/api/foundation/campaigns",   // 캠페인
                                 "/api/foundation/campaigns/*/detail"   // 캠페인
                         ).permitAll()
+                        // 그 외 단체 전용 기능은 ROLE_FOUNDATION 필요
                         .anyRequest().hasAuthority("ROLE_FOUNDATION")
                 )
                 .exceptionHandling(ex -> ex
@@ -130,32 +131,51 @@ public class SecurityConfig {
         return http.build();
     }
 
-    /**
-     * 4. 일반 사용자 및 공통 필터 체인 (Default)
-     */
+    //일반 사용자
     @Bean
-    public SecurityFilterChain defaultFilterChain(HttpSecurity http, JwtFilter jwtFilter) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtFilter jwtFilter) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
                 .authorizeHttpRequests(auth -> auth
+                        // 1. [공개 경로] 누구나 접근 가능
                         .requestMatchers(
-                                "/", "/error", "/favicon.ico", "/uploads/**",
-                                "/api/auth/**", "/api/signup/**", "/api/blockchain/**",
-                                "/oauth2/**", "/login/**", "/social-info", "/users/support/**"
+                                "/",
+                                "/error",
+                                "/favicon.ico",
+                                "/uploads/**",
+                                "/api/auth/**",
+                                "/api/signup/**",
+                                // 블록체인 대시보드/조회 API는 프론트 대시보드 초기 연동을 위해 우선 공개.
+                                // 추후 인증 정책 확정 시 role 기반 접근 제어로 전환 가능.
+                                "/api/blockchain/**",
+                                "/oauth2/**",
+                                "/login/**",
+                                "/social-info",
+                                "/users/support/**"
                         ).permitAll()
+
+                        // 2. [인증 경로] 로그인한 사용자만 가능
+                        .requestMatchers("/finalReport/**").authenticated()
+
+                        // 3. 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated()
                 )
+
+                // OAuth2 로그인 설정
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
                 )
+
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler)
                 )
+
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/merge/final_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/merge/final_project/global/config/SecurityConfig.java
@@ -71,16 +71,16 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain beneficiaryFilterChain(HttpSecurity http, JwtFilter jwtFilter) throws Exception {
         http
-                .securityMatcher("/api/beneficiary/**", "/finalReport/**") // 수혜자 전용 경로 지정
+                .securityMatcher("/api/beneficiary/", "/finalReport/", "/api/v1/**")
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        // 수혜자 로그인/회원가입은 인증 없이 접근 가능
+                        // 수혜자 로그인/회원가입은 공개 (v1 포함)
                         .requestMatchers("/api/beneficiary/signup", "/api/beneficiary/signin").permitAll()
-
-                        // 그 외 보고서 작성 등은 모두 인증 필요
+                        .requestMatchers("/api/v1/beneficiary/signup", "/api/v1/beneficiary/signin").permitAll()
+                        // 그 외 수혜자/보고서 관련은 인증 필요
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex


### PR DESCRIPTION
## 작업 개요
리엑트 연동을 위한 캠페인 컨트롤러 변경

## 작업 내용
<!-- 수행한 작업의 주요 내용을 정리해 주세요 -->
- [ ] 항목 1  
  - 리엑트 연동을 위한 캠페인 컨트롤러 변경


## 관련 이슈
<!-- 이 PR이 해결하거나 관련된 이슈 번호를 작성해 주세요 -->
<!-- PR 병합될 시 해당 이슈가 자동으로 닫힙니다.--> 
- 이슈 번호: [#](예: #1)

## 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
- 예: 이 부분의 로직이 적절한지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 캠프레인 등록 시 등록 번호, 승인 상태, 캠프레인 상태를 포함한 상세한 응답 정보 제공
- 캠프레인 상세 정보 조회 API 엔드포인트 추가

## 개선사항
- 캠프레인 상태에 '승인' 및 '거절' 상태 추가로 승인 워크플로우 강화
- 보안 구성 개선 (비밀번호 암호화 및 인증 관리 강화)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->