### PR TITLE
23/feat/user activatation and email operation/gabeen

### DIFF
--- a/src/main/java/com/merge/final_project/admin/controller/AdminEmailSendListController.java
+++ b/src/main/java/com/merge/final_project/admin/controller/AdminEmailSendListController.java
@@ -1,0 +1,39 @@
+package com.merge.final_project.admin.controller;
+
+import com.merge.final_project.notification.email.EmailTemplateType;
+import com.merge.final_project.notification.email.history.EmailSendListRepository;
+import com.merge.final_project.notification.email.history.EmailSendListResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/email-send-list")
+@RequiredArgsConstructor
+public class AdminEmailSendListController {
+
+    private final EmailSendListRepository emailSendListRepository;
+
+    // 메일 발송 내역 목록 조회 (templateType 필터 선택 가능, 기본 최신순)
+    @GetMapping
+    public ResponseEntity<Page<EmailSendListResponseDTO>> getEmailSendList(
+            @RequestParam(required = false) EmailTemplateType templateType,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        if (templateType != null) {
+            return ResponseEntity.ok(
+                    emailSendListRepository.findByTemplateType(templateType, pageable)
+                            .map(EmailSendListResponseDTO::from));
+        }
+        return ResponseEntity.ok(
+                emailSendListRepository.findAll(pageable)
+                        .map(EmailSendListResponseDTO::from));
+    }
+}

--- a/src/main/java/com/merge/final_project/admin/controller/AdminFoundationController.java
+++ b/src/main/java/com/merge/final_project/admin/controller/AdminFoundationController.java
@@ -42,4 +42,18 @@ public class AdminFoundationController {
         foundationService.rejectFoundationForIllegal(foundationNo);
         return ResponseEntity.ok().build();
     }
+
+    // [가빈] 기부단체 활성화 (임시 비밀번호 발급 + 메일 발송)
+    @PatchMapping("/{foundationNo}/activate")
+    public ResponseEntity<Void> activate(@PathVariable Long foundationNo) {
+        foundationService.activateFoundation(foundationNo);
+        return ResponseEntity.ok().build();
+    }
+
+    // [가빈] 기부단체 비활성화 (비활성화 메일 발송)
+    @PatchMapping("/{foundationNo}/deactivate")
+    public ResponseEntity<Void> deactivate(@PathVariable Long foundationNo) {
+        foundationService.deactivateFoundation(foundationNo);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/merge/final_project/admin/controller/AdminUserController.java
+++ b/src/main/java/com/merge/final_project/admin/controller/AdminUserController.java
@@ -1,0 +1,33 @@
+package com.merge.final_project.admin.controller;
+
+import com.merge.final_project.admin.service.AdminUserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// [가빈] 관리자 회원 활성화/비활성화 컨트롤러
+// 회원 관련 나머지 기능(조회 등)은 이채원 팀원 코드 참고
+@RestController
+@RequestMapping("/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final AdminUserService adminUserService;
+
+    // 회원 활성화
+    @PatchMapping("/{userNo}/activate")
+    public ResponseEntity<Void> activate(@PathVariable Long userNo) {
+        adminUserService.activateUser(userNo);
+        return ResponseEntity.ok().build();
+    }
+
+    // 회원 비활성화
+    @PatchMapping("/{userNo}/deactivate")
+    public ResponseEntity<Void> deactivate(@PathVariable Long userNo) {
+        adminUserService.deactivateUser(userNo);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/merge/final_project/admin/service/AdminUserService.java
+++ b/src/main/java/com/merge/final_project/admin/service/AdminUserService.java
@@ -1,0 +1,8 @@
+package com.merge.final_project.admin.service;
+
+// [가빈] 관리자 회원 활성화/비활성화 서비스
+// 팀원(이채원) UserService와 분리하여 관리자 전용 기능만 여기서 처리
+public interface AdminUserService {
+    void activateUser(Long userNo);
+    void deactivateUser(Long userNo);
+}

--- a/src/main/java/com/merge/final_project/admin/service/AdminUserServiceImpl.java
+++ b/src/main/java/com/merge/final_project/admin/service/AdminUserServiceImpl.java
@@ -1,0 +1,68 @@
+package com.merge.final_project.admin.service;
+
+import com.merge.final_project.admin.Admin;
+import com.merge.final_project.admin.AdminRepository;
+import com.merge.final_project.admin.adminlog.ActionType;
+import com.merge.final_project.admin.adminlog.AdminLogService;
+import com.merge.final_project.admin.adminlog.TargetType;
+import com.merge.final_project.global.exceptions.BusinessException;
+import com.merge.final_project.global.exceptions.ErrorCode;
+import com.merge.final_project.user.users.User;
+import com.merge.final_project.user.users.UserRepository;
+import com.merge.final_project.user.users.UserStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserServiceImpl implements AdminUserService {
+
+    private final UserRepository userRepository;
+    private final AdminRepository adminRepository;
+    private final AdminLogService adminLogService;
+
+    @Transactional
+    @Override
+    public void activateUser(Long userNo) {
+        User user = userRepository.findById(userNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getStatus() == UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_ACTIVE);
+        }
+
+        user.activate();
+
+        Admin admin = getAdmin();
+        adminLogService.log(ActionType.APPROVE, TargetType.USERS, userNo,
+                user.getName() + " 회원 활성화", admin);
+    }
+
+    @Transactional
+    @Override
+    public void deactivateUser(Long userNo) {
+        User user = userRepository.findById(userNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getStatus() == UserStatus.INACTIVE) {
+            throw new BusinessException(ErrorCode.USER_ALREADY_INACTIVE);
+        }
+
+        user.deactivate();
+
+        Admin admin = getAdmin();
+        adminLogService.log(ActionType.REJECT, TargetType.USERS, userNo,
+                user.getName() + " 회원 비활성화", admin);
+    }
+
+    private Admin getAdmin() {
+        String adminId = Objects.requireNonNull(
+                SecurityContextHolder.getContext().getAuthentication()).getName();
+        return adminRepository.findByAdminId(adminId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADMIN_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/merge/final_project/global/exceptions/ErrorCode.java
+++ b/src/main/java/com/merge/final_project/global/exceptions/ErrorCode.java
@@ -17,6 +17,12 @@ public enum ErrorCode {
     CANNOT_APPROVE_ILLEGAL_FOUNDATION(HttpStatus.CONFLICT, "FOUNDATION_003", "불성실기부단체에 포함되는 단체는 가입이 안됩니다."),
     FOUNDATION_LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "FOUNDATION_004", "이메일 또는 비밀번호가 올바르지 않습니다."),
     FOUNDATION_NOT_ACTIVATED(HttpStatus.FORBIDDEN, "FOUNDATION_005", "승인되지 않은 단체입니다. 관리자 승인 후 로그인 가능합니다."),
+    FOUNDATION_ALREADY_ACTIVE(HttpStatus.CONFLICT, "FOUNDATION_006", "이미 활성화된 기부단체입니다."),
+    FOUNDATION_ALREADY_INACTIVE(HttpStatus.CONFLICT, "FOUNDATION_007", "이미 비활성화된 기부단체입니다."),
+    // 회원
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "존재하지 않는 회원입니다."),
+    USER_ALREADY_ACTIVE(HttpStatus.CONFLICT, "USER_002", "이미 활성화된 회원입니다."),
+    USER_ALREADY_INACTIVE(HttpStatus.CONFLICT, "USER_003", "이미 비활성화된 회원입니다."),
     // 파일 관련
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_001", "파일 업로드에 실패했습니다."),
     FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_002", "파일 업로드 중 오류가 발생했습니다."),

--- a/src/main/java/com/merge/final_project/notification/email/EmailTemplateType.java
+++ b/src/main/java/com/merge/final_project/notification/email/EmailTemplateType.java
@@ -3,5 +3,7 @@ package com.merge.final_project.notification.email;
 public enum EmailTemplateType {
     DONATION_COMPLETE, CAMPAIGN_APPROVED, CAMPAIGN_REJECTED,
     CAMPAIGN_ACHIEVED, PASSWORD_RESET, ACCOUNT_APPROVED, ACCOUNT_REJECTED,
-    FOUNDATION_TEMP_PASSWORD
+    FOUNDATION_TEMP_PASSWORD,
+    FOUNDATION_INACTIVE_BATCH,       // 배치 자동 비활성화 (활동 보고서 14일 미제출)
+    FOUNDATION_DEACTIVATED_BY_ADMIN  // 관리자 직접 비활성화
 }

--- a/src/main/java/com/merge/final_project/notification/email/GmailService.java
+++ b/src/main/java/com/merge/final_project/notification/email/GmailService.java
@@ -6,4 +6,6 @@ public interface GmailService {
     CompletableFuture<Void> sendSignupMail(String to, String foundationName, String tempPassword);
     CompletableFuture<Void> sendRejectMail(String to, String foundationName, String rejectReason);
     CompletableFuture<Void> sendInactiveMail(String to, String foundationName, String campaignTitle);
+    // [가빈] 관리자 직접 비활성화 시 발송 (배치 비활성화와 다른 템플릿 사용)
+    CompletableFuture<Void> sendDeactivateByAdminMail(String to, String foundationName);
 }

--- a/src/main/java/com/merge/final_project/notification/email/GmailServiceImpl.java
+++ b/src/main/java/com/merge/final_project/notification/email/GmailServiceImpl.java
@@ -91,4 +91,27 @@ public class GmailServiceImpl implements GmailService {
 
         return CompletableFuture.completedFuture(null);
     }
+
+    // [가빈] 관리자 직접 비활성화 메일 (배치 비활성화와 분리 — 캠페인 제목 없음)
+    @Override
+    public CompletableFuture<Void> sendDeactivateByAdminMail(String to, String foundationName) {
+        Context context = new Context();
+        context.setVariable("foundationName", foundationName);
+
+        String html = templateEngine.process("mail/deactivate-by-admin-mail", context);
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, "UTF-8");
+            helper.setTo(to);
+            helper.setSubject("[giveNtoken] 계정 비활성화 안내");
+            helper.setText(html, true);
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            log.error("메일 발송 실패 - 수신주소: {}", to);
+            throw new BusinessException(ErrorCode.MAIL_SEND_FAILED);
+        }
+
+        return CompletableFuture.completedFuture(null);
+    }
 }

--- a/src/main/java/com/merge/final_project/notification/email/event/FoundationDeactivatedByAdminEvent.java
+++ b/src/main/java/com/merge/final_project/notification/email/event/FoundationDeactivatedByAdminEvent.java
@@ -1,0 +1,13 @@
+package com.merge.final_project.notification.email.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+// [가빈] 관리자가 직접 기부단체를 비활성화할 때 발행하는 이벤트.
+// 배치 비활성화(FoundationInactiveEvent)와 분리 — 배치용은 캠페인 제목이 필요하지만 이건 불필요함.
+@AllArgsConstructor
+@Getter
+public class FoundationDeactivatedByAdminEvent {
+    private final String email;
+    private final String foundationName;
+}

--- a/src/main/java/com/merge/final_project/notification/email/event/FoundationEventListener.java
+++ b/src/main/java/com/merge/final_project/notification/email/event/FoundationEventListener.java
@@ -1,35 +1,103 @@
 package com.merge.final_project.notification.email.event;
 
+import com.merge.final_project.notification.email.EmailStatus;
+import com.merge.final_project.notification.email.EmailTemplateType;
 import com.merge.final_project.notification.email.GmailService;
+import com.merge.final_project.notification.email.history.EmailSendList;
+import com.merge.final_project.notification.email.history.EmailSendListRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.time.LocalDateTime;
 import java.util.concurrent.CompletableFuture;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FoundationEventListener {
 
     private final GmailService gmailService;
+    private final EmailSendListRepository emailSendListRepository;
+
+    private static final String DELIMITER = "||";
 
     @Async
+    @Transactional
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public CompletableFuture<Void> handleApproved(FoundationApprovedEvent event) {
-        return gmailService.sendSignupMail(event.getEmail(), event.getFoundationName(), event.getTempPassword());
+        // content = "foundationName||tempPassword(평문)" — 재시도 시 필요
+        EmailSendList record = emailSendListRepository.save(EmailSendList.builder()
+                .recipientEmail(event.getEmail())
+                .templateType(EmailTemplateType.ACCOUNT_APPROVED)
+                .title("[giveNtoken] 가입 신청 승인 및 임시 비밀번호 안내")
+                .content(event.getFoundationName() + DELIMITER + event.getTempPassword())
+                .emailStatus(EmailStatus.PENDING)
+                .build());
+        trySend(() -> gmailService.sendSignupMail(event.getEmail(), event.getFoundationName(), event.getTempPassword()), record);
+        return CompletableFuture.completedFuture(null);
     }
 
     @Async
+    @Transactional
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public CompletableFuture<Void> handleRejected(FoundationRejectedEvent event) {
-        return gmailService.sendRejectMail(event.getEmail(), event.getFoundationName(), event.getRejectedReason());
+        // content = "foundationName||rejectReason"
+        EmailSendList record = emailSendListRepository.save(EmailSendList.builder()
+                .recipientEmail(event.getEmail())
+                .templateType(EmailTemplateType.ACCOUNT_REJECTED)
+                .title("[giveNtoken] 가입 신청 반려 안내")
+                .content(event.getFoundationName() + DELIMITER + event.getRejectedReason())
+                .emailStatus(EmailStatus.PENDING)
+                .build());
+        trySend(() -> gmailService.sendRejectMail(event.getEmail(), event.getFoundationName(), event.getRejectedReason()), record);
+        return CompletableFuture.completedFuture(null);
     }
 
     @Async
+    @Transactional
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public CompletableFuture<Void> handleInactive(FoundationInactiveEvent event) {
-        return gmailService.sendInactiveMail(event.getEmail(), event.getFoundationName(), event.getCampaignTitle());
+        // content = "foundationName||campaignTitle"
+        EmailSendList record = emailSendListRepository.save(EmailSendList.builder()
+                .recipientEmail(event.getEmail())
+                .templateType(EmailTemplateType.FOUNDATION_INACTIVE_BATCH)
+                .title("[giveNtoken] 계정 비활성화 안내")
+                .content(event.getFoundationName() + DELIMITER + event.getCampaignTitle())
+                .emailStatus(EmailStatus.PENDING)
+                .build());
+        trySend(() -> gmailService.sendInactiveMail(event.getEmail(), event.getFoundationName(), event.getCampaignTitle()), record);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    // [가빈] 관리자 직접 비활성화 메일 핸들러
+    @Async
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public CompletableFuture<Void> handleDeactivatedByAdmin(FoundationDeactivatedByAdminEvent event) {
+        // content = foundationName
+        EmailSendList record = emailSendListRepository.save(EmailSendList.builder()
+                .recipientEmail(event.getEmail())
+                .templateType(EmailTemplateType.FOUNDATION_DEACTIVATED_BY_ADMIN)
+                .title("[giveNtoken] 계정 비활성화 안내")
+                .content(event.getFoundationName())
+                .emailStatus(EmailStatus.PENDING)
+                .build());
+        trySend(() -> gmailService.sendDeactivateByAdminMail(event.getEmail(), event.getFoundationName()), record);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private void trySend(Runnable sendTask, EmailSendList record) {
+        try {
+            sendTask.run();
+            record.markSent();
+        } catch (Exception e) {
+            record.markFailed();
+            log.error("메일 발송 실패 - recipientEmail: {}, templateType: {}", record.getRecipientEmail(), record.getTemplateType());
+        }
     }
 }

--- a/src/main/java/com/merge/final_project/notification/email/history/EmailSendList.java
+++ b/src/main/java/com/merge/final_project/notification/email/history/EmailSendList.java
@@ -1,0 +1,55 @@
+package com.merge.final_project.notification.email.history;
+
+import com.merge.final_project.global.BaseEntity;
+import com.merge.final_project.notification.email.EmailStatus;
+import com.merge.final_project.notification.email.EmailTemplateType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "email_send_list")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmailSendList extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "email_queue_no")
+    private Long emailQueueNo;
+
+    @Column(name = "recipient_email", nullable = false)
+    private String recipientEmail;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "template_type")
+    private EmailTemplateType templateType;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "email_status")
+    private EmailStatus emailStatus;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    public void markSent() {
+        this.emailStatus = EmailStatus.SENT;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    public void markFailed() {
+        this.emailStatus = EmailStatus.FAILED;
+    }
+}

--- a/src/main/java/com/merge/final_project/notification/email/history/EmailSendListRepository.java
+++ b/src/main/java/com/merge/final_project/notification/email/history/EmailSendListRepository.java
@@ -1,0 +1,14 @@
+package com.merge.final_project.notification.email.history;
+
+import com.merge.final_project.notification.email.EmailStatus;
+import com.merge.final_project.notification.email.EmailTemplateType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EmailSendListRepository extends JpaRepository<EmailSendList, Long> {
+    Page<EmailSendList> findByTemplateType(EmailTemplateType templateType, Pageable pageable);
+    List<EmailSendList> findByEmailStatus(EmailStatus emailStatus);
+}

--- a/src/main/java/com/merge/final_project/notification/email/history/EmailSendListResponseDTO.java
+++ b/src/main/java/com/merge/final_project/notification/email/history/EmailSendListResponseDTO.java
@@ -1,0 +1,32 @@
+package com.merge.final_project.notification.email.history;
+
+import com.merge.final_project.notification.email.EmailStatus;
+import com.merge.final_project.notification.email.EmailTemplateType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class EmailSendListResponseDTO {
+    private Long emailQueueNo;
+    private String recipientEmail;
+    private EmailTemplateType templateType;
+    private String title;
+    private EmailStatus emailStatus;
+    private LocalDateTime sentAt;
+    private LocalDateTime createdAt;
+
+    public static EmailSendListResponseDTO from(EmailSendList emailSendList) {
+        return EmailSendListResponseDTO.builder()
+                .emailQueueNo(emailSendList.getEmailQueueNo())
+                .recipientEmail(emailSendList.getRecipientEmail())
+                .templateType(emailSendList.getTemplateType())
+                .title(emailSendList.getTitle())
+                .emailStatus(emailSendList.getEmailStatus())
+                .sentAt(emailSendList.getSentAt())
+                .createdAt(emailSendList.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/merge/final_project/notification/email/retry/EmailRetryScheduler.java
+++ b/src/main/java/com/merge/final_project/notification/email/retry/EmailRetryScheduler.java
@@ -1,0 +1,22 @@
+package com.merge.final_project.notification.email.retry;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailRetryScheduler {
+
+    private final EmailRetryService emailRetryService;
+
+    // 매일 새벽 2시 — 전날 실패한 메일 재시도
+    @Scheduled(cron = "0 0 2 * * *")
+    public void retryFailedEmails() {
+        log.info("메일 재시도 배치 시작");
+        emailRetryService.retryFailed();
+        log.info("메일 재시도 배치 완료");
+    }
+}

--- a/src/main/java/com/merge/final_project/notification/email/retry/EmailRetryService.java
+++ b/src/main/java/com/merge/final_project/notification/email/retry/EmailRetryService.java
@@ -1,0 +1,78 @@
+package com.merge.final_project.notification.email.retry;
+
+import com.merge.final_project.notification.email.EmailStatus;
+import com.merge.final_project.notification.email.GmailService;
+import com.merge.final_project.notification.email.history.EmailSendList;
+import com.merge.final_project.notification.email.history.EmailSendListRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailRetryService {
+
+    private static final String DELIMITER = "||";
+
+    private final EmailSendListRepository emailSendListRepository;
+    private final GmailService gmailService;
+
+    @Transactional
+    public void retryFailed() {
+        List<EmailSendList> failedList = emailSendListRepository.findByEmailStatus(EmailStatus.FAILED);
+
+        if (failedList.isEmpty()) {
+            log.info("재시도 대상 메일 없음");
+            return;
+        }
+
+        log.info("메일 재시도 시작 - 대상 건수: {}", failedList.size());
+
+        for (EmailSendList record : failedList) {
+            try {
+                resend(record);
+                record.markSent();
+                log.info("메일 재시도 성공 emailQueueNo={}", record.getEmailQueueNo());
+            } catch (Exception e) {
+                record.markFailed();
+                log.error("메일 재시도 실패 emailQueueNo={}, templateType={}", record.getEmailQueueNo(), record.getTemplateType());
+            }
+        }
+    }
+
+    private void resend(EmailSendList record) {
+        String email = record.getRecipientEmail();
+        String[] parts = record.getContent() != null ? record.getContent().split("\\|\\|", 2) : new String[]{};
+
+        switch (record.getTemplateType()) {
+            case ACCOUNT_APPROVED -> {
+                // content = "foundationName||tempPassword"
+                String foundationName = parts[0];
+                String tempPassword = parts[1];
+                gmailService.sendSignupMail(email, foundationName, tempPassword);
+            }
+            case ACCOUNT_REJECTED -> {
+                // content = "foundationName||rejectReason"
+                String foundationName = parts[0];
+                String rejectReason = parts[1];
+                gmailService.sendRejectMail(email, foundationName, rejectReason);
+            }
+            case FOUNDATION_INACTIVE_BATCH -> {
+                // content = "foundationName||campaignTitle"
+                String foundationName = parts[0];
+                String campaignTitle = parts[1];
+                gmailService.sendInactiveMail(email, foundationName, campaignTitle);
+            }
+            case FOUNDATION_DEACTIVATED_BY_ADMIN -> {
+                // content = foundationName
+                String foundationName = parts[0];
+                gmailService.sendDeactivateByAdminMail(email, foundationName);
+            }
+            default -> throw new IllegalArgumentException("재시도 미지원 templateType: " + record.getTemplateType());
+        }
+    }
+}

--- a/src/main/java/com/merge/final_project/org/Foundation.java
+++ b/src/main/java/com/merge/final_project/org/Foundation.java
@@ -117,4 +117,9 @@ public class Foundation extends BaseEntity {
         this.accountStatus = AccountStatus.INACTIVE;
     }
 
+    // [가빈] 관리자 직접 활성화 — reviewStatus는 건드리지 않고 accountStatus만 ACTIVE로 변경 + 임시 비밀번호 재발급
+    public void activate() {
+        this.accountStatus = AccountStatus.ACTIVE;
+    }
+
 }

--- a/src/main/java/com/merge/final_project/org/FoundationService.java
+++ b/src/main/java/com/merge/final_project/org/FoundationService.java
@@ -27,5 +27,10 @@ public interface FoundationService {
     Long approveFoundation(Long foundationNo);
     Long rejectFoundationForIllegal(Long foundationNo);
 
+    // [가빈] 관리자 기부단체 활성화 (임시 비밀번호 발급 + 메일 발송)
+    void activateFoundation(Long foundationNo);
+    // [가빈] 관리자 기부단체 비활성화
+    void deactivateFoundation(Long foundationNo);
+
     Page<CampaignListResponseDTO> getMyCampaigns(Long foundationNo, Pageable pageable);
 }

--- a/src/main/java/com/merge/final_project/org/FoundationServiceImpl.java
+++ b/src/main/java/com/merge/final_project/org/FoundationServiceImpl.java
@@ -14,6 +14,7 @@ import com.merge.final_project.global.exceptions.ErrorCode;
 import com.merge.final_project.global.jwt.JwtTokenProvider;
 import com.merge.final_project.global.utils.FileUtil;
 import com.merge.final_project.notification.email.event.FoundationApprovedEvent;
+import com.merge.final_project.notification.email.event.FoundationDeactivatedByAdminEvent;
 import com.merge.final_project.notification.email.event.FoundationRejectedEvent;
 import com.merge.final_project.org.dto.*;
 import com.merge.final_project.org.illegalfoundation.IllegalFoundation;
@@ -366,6 +367,65 @@ public class FoundationServiceImpl implements FoundationService {
         adminLogService.log(ActionType.REJECT, TargetType.FOUNDATION, foundationNo, description, admin);
 
         return foundation.getFoundationNo();
+    }
+
+    // [가빈] 관리자 기부단체 활성화 — 비활성화된 APPROVED 단체를 다시 ACTIVE로 전환 + 임시 비밀번호 재발급 + 메일 발송
+    @Transactional
+    @Override
+    public void activateFoundation(Long foundationNo) {
+        Foundation foundation = foundationRepository.findById(foundationNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FOUNDATION_NOT_FOUND));
+
+        if (foundation.getAccountStatus() == AccountStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.FOUNDATION_ALREADY_ACTIVE);
+        }
+
+        // APPROVED 상태인 단체만 활성화 가능 (PRE_REGISTERED, REJECTED 단체는 활성화 불가)
+        if (foundation.getReviewStatus() != ReviewStatus.APPROVED) {
+            throw new BusinessException(ErrorCode.CANNOT_APPROVE_ILLEGAL_FOUNDATION);
+        }
+
+        foundation.activate();
+
+        // 임시 비밀번호 재발급
+        String sendTempPassword = String.valueOf(UUID.randomUUID());
+        foundation.updatePassword(passwordEncoder.encode(sendTempPassword));
+
+        // 트랜잭션 커밋 후 메일 발송
+        eventPublisher.publishEvent(new FoundationApprovedEvent(
+                foundationNo, foundation.getFoundationEmail(), foundation.getFoundationName(), sendTempPassword));
+
+        // 관리자 활동 로그
+        String adminId = Objects.requireNonNull(SecurityContextHolder.getContext().getAuthentication()).getName();
+        Admin admin = adminRepository.findByAdminId(adminId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADMIN_NOT_FOUND));
+        adminLogService.log(ActionType.APPROVE, TargetType.FOUNDATION, foundationNo,
+                foundation.getFoundationName() + " 기부단체 활성화 + 임시 비밀번호 메일 전송", admin);
+    }
+
+    // [가빈] 관리자 기부단체 비활성화 — ACTIVE 단체를 INACTIVE로 전환 + 비활성화 메일 발송
+    @Transactional
+    @Override
+    public void deactivateFoundation(Long foundationNo) {
+        Foundation foundation = foundationRepository.findById(foundationNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FOUNDATION_NOT_FOUND));
+
+        if (foundation.getAccountStatus() == AccountStatus.INACTIVE) {
+            throw new BusinessException(ErrorCode.FOUNDATION_ALREADY_INACTIVE);
+        }
+
+        foundation.deactivate();
+
+        // 트랜잭션 커밋 후 비활성화 메일 발송
+        eventPublisher.publishEvent(new FoundationDeactivatedByAdminEvent(
+                foundation.getFoundationEmail(), foundation.getFoundationName()));
+
+        // 관리자 활동 로그
+        String adminId = Objects.requireNonNull(SecurityContextHolder.getContext().getAuthentication()).getName();
+        Admin admin = adminRepository.findByAdminId(adminId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADMIN_NOT_FOUND));
+        adminLogService.log(ActionType.REJECT, TargetType.FOUNDATION, foundationNo,
+                foundation.getFoundationName() + " 기부단체 비활성화 + 메일 전송", admin);
     }
 
     @Override

--- a/src/main/java/com/merge/final_project/user/users/User.java
+++ b/src/main/java/com/merge/final_project/user/users/User.java
@@ -80,4 +80,13 @@ public class User {
     public void setsLoginCount(Integer loginCount) {
         this.loginCount = loginCount;
     }
+
+    // [가빈] 관리자 활성화/비활성화 기능 추가하면서 setter 대신 도메인 메서드로 추가함
+    public void activate() {
+        this.status = UserStatus.ACTIVE;
+    }
+
+    public void deactivate() {
+        this.status = UserStatus.INACTIVE;
+    }
 }

--- a/src/main/resources/templates/mail/deactivate-by-admin-mail.html
+++ b/src/main/resources/templates/mail/deactivate-by-admin-mail.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>계정 비활성화 안내</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+<div style="max-width: 600px; margin: 0 auto; padding: 24px; border: 1px solid #ddd; border-radius: 8px;">
+    <h2 style="color: #c0392b;">계정 비활성화 안내</h2>
+
+    <p>
+        안녕하세요,
+        <strong th:text="${foundationName}">단체명</strong> 담당자님.
+    </p>
+
+    <p>
+        관리자의 검토 결과 귀 단체 계정이 <strong style="color: #c0392b;">비활성화</strong>되었습니다.
+    </p>
+
+    <p>
+        계정 복구 또는 이의 신청은 플랫폼 고객센터로 연락해 주세요.
+    </p>
+
+    <hr style="margin: 24px 0;">
+
+    <p style="font-size: 12px; color: #888;">
+        본 메일은 발신 전용입니다.
+    </p>
+</div>
+</body>
+</html>

--- a/src/test/java/com/merge/final_project/admin/AdminUserServiceTest.java
+++ b/src/test/java/com/merge/final_project/admin/AdminUserServiceTest.java
@@ -1,0 +1,130 @@
+package com.merge.final_project.admin;
+
+import com.merge.final_project.admin.adminlog.AdminLogService;
+import com.merge.final_project.admin.service.AdminUserServiceImpl;
+import com.merge.final_project.global.exceptions.BusinessException;
+import com.merge.final_project.global.exceptions.ErrorCode;
+import com.merge.final_project.user.users.User;
+import com.merge.final_project.user.users.UserRepository;
+import com.merge.final_project.user.users.UserStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUserServiceTest {
+
+    @InjectMocks
+    private AdminUserServiceImpl adminUserService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AdminRepository adminRepository;
+
+    @Mock
+    private AdminLogService adminLogService;
+
+    @BeforeEach
+    void setUp() {
+        var auth = new UsernamePasswordAuthenticationToken("testAdmin", null, List.of());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        Admin mockAdmin = mock(Admin.class);
+        lenient().when(adminRepository.findByAdminId("testAdmin")).thenReturn(Optional.of(mockAdmin));
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("비활성화된 회원을 활성화하면 ACTIVE 상태가 된다")
+    void 회원_활성화_성공() {
+        User user = mock(User.class);
+        when(user.getStatus()).thenReturn(UserStatus.INACTIVE);
+        when(user.getName()).thenReturn("홍길동");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        adminUserService.activateUser(1L);
+
+        verify(user).activate();
+    }
+
+    @Test
+    @DisplayName("이미 활성화된 회원을 활성화 시도하면 USER_ALREADY_ACTIVE 예외가 발생한다")
+    void 회원_활성화_이미활성화_예외() {
+        User user = mock(User.class);
+        when(user.getStatus()).thenReturn(UserStatus.ACTIVE);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> adminUserService.activateUser(1L));
+
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.USER_ALREADY_ACTIVE.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 활성화 시도 시 USER_NOT_FOUND 예외가 발생한다")
+    void 회원_활성화_없는회원_예외() {
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> adminUserService.activateUser(999L));
+
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("활성화된 회원을 비활성화하면 INACTIVE 상태가 된다")
+    void 회원_비활성화_성공() {
+        User user = mock(User.class);
+        when(user.getStatus()).thenReturn(UserStatus.ACTIVE);
+        when(user.getName()).thenReturn("홍길동");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        adminUserService.deactivateUser(1L);
+
+        verify(user).deactivate();
+    }
+
+    @Test
+    @DisplayName("이미 비활성화된 회원을 비활성화 시도하면 USER_ALREADY_INACTIVE 예외가 발생한다")
+    void 회원_비활성화_이미비활성화_예외() {
+        User user = mock(User.class);
+        when(user.getStatus()).thenReturn(UserStatus.INACTIVE);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> adminUserService.deactivateUser(1L));
+
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.USER_ALREADY_INACTIVE.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 비활성화 시도 시 USER_NOT_FOUND 예외가 발생한다")
+    void 회원_비활성화_없는회원_예외() {
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> adminUserService.deactivateUser(999L));
+
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+}

--- a/src/test/java/com/merge/final_project/notification/FoundationEventListenerTest.java
+++ b/src/test/java/com/merge/final_project/notification/FoundationEventListenerTest.java
@@ -1,0 +1,105 @@
+package com.merge.final_project.notification;
+
+import com.merge.final_project.notification.email.EmailStatus;
+import com.merge.final_project.notification.email.EmailTemplateType;
+import com.merge.final_project.notification.email.GmailService;
+import com.merge.final_project.notification.email.event.*;
+import com.merge.final_project.notification.email.history.EmailSendList;
+import com.merge.final_project.notification.email.history.EmailSendListRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FoundationEventListenerTest {
+
+    @InjectMocks
+    private FoundationEventListener foundationEventListener;
+
+    @Mock
+    private GmailService gmailService;
+
+    @Mock
+    private EmailSendListRepository emailSendListRepository;
+
+    @Test
+    @DisplayName("승인 이벤트 발생 시 메일이 발송되고 ACCOUNT_APPROVED 내역이 저장된다")
+    void 승인_메일_발송_내역저장() {
+        FoundationApprovedEvent event = new FoundationApprovedEvent(1L, "test@test.com", "테스트단체", "tempPw");
+
+        foundationEventListener.handleApproved(event);
+
+        verify(gmailService).sendSignupMail("test@test.com", "테스트단체", "tempPw");
+
+        ArgumentCaptor<EmailSendList> captor = ArgumentCaptor.forClass(EmailSendList.class);
+        verify(emailSendListRepository).save(captor.capture());
+        assertThat(captor.getValue().getTemplateType()).isEqualTo(EmailTemplateType.ACCOUNT_APPROVED);
+        assertThat(captor.getValue().getEmailStatus()).isEqualTo(EmailStatus.SENT);
+        assertThat(captor.getValue().getRecipientEmail()).isEqualTo("test@test.com");
+    }
+
+    @Test
+    @DisplayName("반려 이벤트 발생 시 메일이 발송되고 ACCOUNT_REJECTED 내역이 저장된다")
+    void 반려_메일_발송_내역저장() {
+        FoundationRejectedEvent event = new FoundationRejectedEvent(1L, "test@test.com", "테스트단체", "기부금 횡령");
+
+        foundationEventListener.handleRejected(event);
+
+        verify(gmailService).sendRejectMail("test@test.com", "테스트단체", "기부금 횡령");
+
+        ArgumentCaptor<EmailSendList> captor = ArgumentCaptor.forClass(EmailSendList.class);
+        verify(emailSendListRepository).save(captor.capture());
+        assertThat(captor.getValue().getTemplateType()).isEqualTo(EmailTemplateType.ACCOUNT_REJECTED);
+        assertThat(captor.getValue().getEmailStatus()).isEqualTo(EmailStatus.SENT);
+    }
+
+    @Test
+    @DisplayName("배치 비활성화 이벤트 발생 시 메일이 발송되고 FOUNDATION_INACTIVE_BATCH 내역이 저장된다")
+    void 배치_비활성화_메일_발송_내역저장() {
+        FoundationInactiveEvent event = new FoundationInactiveEvent("test@test.com", "테스트단체", "캠페인A");
+
+        foundationEventListener.handleInactive(event);
+
+        verify(gmailService).sendInactiveMail("test@test.com", "테스트단체", "캠페인A");
+
+        ArgumentCaptor<EmailSendList> captor = ArgumentCaptor.forClass(EmailSendList.class);
+        verify(emailSendListRepository).save(captor.capture());
+        assertThat(captor.getValue().getTemplateType()).isEqualTo(EmailTemplateType.FOUNDATION_INACTIVE_BATCH);
+        assertThat(captor.getValue().getEmailStatus()).isEqualTo(EmailStatus.SENT);
+    }
+
+    @Test
+    @DisplayName("관리자 직접 비활성화 이벤트 발생 시 메일이 발송되고 FOUNDATION_DEACTIVATED_BY_ADMIN 내역이 저장된다")
+    void 관리자_비활성화_메일_발송_내역저장() {
+        FoundationDeactivatedByAdminEvent event = new FoundationDeactivatedByAdminEvent("test@test.com", "테스트단체");
+
+        foundationEventListener.handleDeactivatedByAdmin(event);
+
+        verify(gmailService).sendDeactivateByAdminMail("test@test.com", "테스트단체");
+
+        ArgumentCaptor<EmailSendList> captor = ArgumentCaptor.forClass(EmailSendList.class);
+        verify(emailSendListRepository).save(captor.capture());
+        assertThat(captor.getValue().getTemplateType()).isEqualTo(EmailTemplateType.FOUNDATION_DEACTIVATED_BY_ADMIN);
+        assertThat(captor.getValue().getEmailStatus()).isEqualTo(EmailStatus.SENT);
+    }
+
+    @Test
+    @DisplayName("메일 발송 실패 시 내역이 저장되지 않는다")
+    void 메일_발송_실패_내역미저장() {
+        FoundationApprovedEvent event = new FoundationApprovedEvent(1L, "test@test.com", "테스트단체", "tempPw");
+        doThrow(new RuntimeException("메일 서버 오류")).when(gmailService)
+                .sendSignupMail(anyString(), anyString(), anyString());
+
+        org.junit.jupiter.api.Assertions.assertThrows(RuntimeException.class,
+                () -> foundationEventListener.handleApproved(event));
+
+        verify(emailSendListRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/merge/final_project/org/FoundationServiceTest.java
+++ b/src/test/java/com/merge/final_project/org/FoundationServiceTest.java
@@ -9,6 +9,7 @@ import com.merge.final_project.global.exceptions.ErrorCode;
 import com.merge.final_project.global.jwt.JwtTokenProvider;
 import com.merge.final_project.global.utils.FileUtil;
 import com.merge.final_project.notification.email.event.FoundationApprovedEvent;
+import com.merge.final_project.notification.email.event.FoundationDeactivatedByAdminEvent;
 import com.merge.final_project.notification.email.event.FoundationRejectedEvent;
 import com.merge.final_project.org.AccountStatus;
 import com.merge.final_project.org.dto.FoundationApplyRequestDTO;
@@ -273,5 +274,89 @@ class FoundationServiceTest {
                 () -> foundationService.rejectFoundationForIllegal(999L));
 
         assertThat(exception.getMessage()).isEqualTo(ErrorCode.FOUNDATION_NOT_FOUND.getMessage());
+    }
+
+    // 기부단체 활성화 테스트
+
+    @Test
+    @DisplayName("비활성화된 승인 단체를 활성화하면 ACTIVE 상태가 되고 승인 이벤트가 발행된다")
+    void 단체_활성화_성공() {
+        Foundation foundation = Foundation.builder()
+                .foundationEmail("test@test.com")
+                .foundationName("테스트단체")
+                .accountStatus(AccountStatus.INACTIVE)
+                .reviewStatus(ReviewStatus.APPROVED)
+                .build();
+        when(foundationRepository.findById(1L)).thenReturn(Optional.of(foundation));
+        when(passwordEncoder.encode(any())).thenReturn("encodedTempPassword");
+
+        foundationService.activateFoundation(1L);
+
+        assertThat(foundation.getAccountStatus()).isEqualTo(AccountStatus.ACTIVE);
+        verify(eventPublisher).publishEvent(any(FoundationApprovedEvent.class));
+    }
+
+    @Test
+    @DisplayName("이미 활성화된 단체를 활성화 시도하면 FOUNDATION_ALREADY_ACTIVE 예외가 발생한다")
+    void 단체_활성화_이미활성화_예외() {
+        Foundation foundation = Foundation.builder()
+                .accountStatus(AccountStatus.ACTIVE)
+                .reviewStatus(ReviewStatus.APPROVED)
+                .build();
+        when(foundationRepository.findById(1L)).thenReturn(Optional.of(foundation));
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> foundationService.activateFoundation(1L));
+
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.FOUNDATION_ALREADY_ACTIVE.getMessage());
+    }
+
+    @Test
+    @DisplayName("미승인 단체는 활성화할 수 없다")
+    void 단체_활성화_미승인_예외() {
+        Foundation foundation = Foundation.builder()
+                .accountStatus(AccountStatus.INACTIVE)
+                .reviewStatus(ReviewStatus.CLEAN)
+                .build();
+        when(foundationRepository.findById(1L)).thenReturn(Optional.of(foundation));
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> foundationService.activateFoundation(1L));
+
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.CANNOT_APPROVE_ILLEGAL_FOUNDATION.getMessage());
+    }
+
+    // 기부단체 비활성화 테스트
+
+    @Test
+    @DisplayName("활성화된 단체를 비활성화하면 INACTIVE 상태가 되고 비활성화 이벤트가 발행된다")
+    void 단체_비활성화_성공() {
+        Foundation foundation = Foundation.builder()
+                .foundationEmail("test@test.com")
+                .foundationName("테스트단체")
+                .accountStatus(AccountStatus.ACTIVE)
+                .reviewStatus(ReviewStatus.APPROVED)
+                .build();
+        when(foundationRepository.findById(1L)).thenReturn(Optional.of(foundation));
+
+        foundationService.deactivateFoundation(1L);
+
+        assertThat(foundation.getAccountStatus()).isEqualTo(AccountStatus.INACTIVE);
+        verify(eventPublisher).publishEvent(any(FoundationDeactivatedByAdminEvent.class));
+    }
+
+    @Test
+    @DisplayName("이미 비활성화된 단체를 비활성화 시도하면 FOUNDATION_ALREADY_INACTIVE 예외가 발생한다")
+    void 단체_비활성화_이미비활성화_예외() {
+        Foundation foundation = Foundation.builder()
+                .accountStatus(AccountStatus.INACTIVE)
+                .reviewStatus(ReviewStatus.APPROVED)
+                .build();
+        when(foundationRepository.findById(1L)).thenReturn(Optional.of(foundation));
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> foundationService.deactivateFoundation(1L));
+
+        assertThat(exception.getMessage()).isEqualTo(ErrorCode.FOUNDATION_ALREADY_INACTIVE.getMessage());
     }
 }


### PR DESCRIPTION
## 작업 개요
관리자의 회원 및 기부단체 활성화/비활성화 기능을 구현했습니다. 비활성화 시 반려 메일을 보내고, 활성화 시 임시 비밀번호를 전달하는 메일 전송까지 연동하여 구현하였음. 메일 보낸 후 메일 내역을 남기는 기능까지 구현해놓음. 

- 이슈 번호: [#](예: #23)

## 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자가 기부단체 및 회원의 계정을 활성화/비활성화할 수 있는 관리 기능 추가
  * 이메일 발송 내역 추적 및 조회 기능 추가
  * 실패한 이메일 자동 재발송 스케줄러 추가
  * 관리자 계정 비활성화 알림 메일 템플릿 추가

* **Tests**
  * 관리자 사용자 관리 기능 테스트 추가
  * 이메일 이벤트 처리 및 발송 내역 저장 테스트 추가
  * 기부단체 상태 전환 기능 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->