### PR TITLE
feat:[김가빈]기부단체 상세보기 페이지 공개용 구현

### DIFF
--- a/src/main/java/com/merge/final_project/admin/controller/AdminFoundationController.java
+++ b/src/main/java/com/merge/final_project/admin/controller/AdminFoundationController.java
@@ -3,6 +3,7 @@ package com.merge.final_project.admin.controller;
 import com.merge.final_project.org.AccountStatus;
 import com.merge.final_project.org.FoundationService;
 import com.merge.final_project.org.ReviewStatus;
+import com.merge.final_project.org.dto.FoundationDetailResponseDTO;
 import com.merge.final_project.org.dto.FoundationListResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,7 +20,12 @@ public class AdminFoundationController {
 
     private final FoundationService foundationService;
 
-    // 상세 조회 및 승인 후 리스트(가입완료) 조회는 추후 다른 곳에서도 쓸 수 있을 것 같아서 관리자 권한에서 제외시킴
+    // 관리자 기부단체 상세 조회 — 민감 정보 포함 (이메일, 계좌, 상태값 등 모두 노출)
+    @GetMapping("/{foundationNo}")
+    public ResponseEntity<FoundationDetailResponseDTO> getDetail(@PathVariable Long foundationNo) {
+        return ResponseEntity.ok(foundationService.getFoundationDetail(foundationNo));
+    }
+
     // 승인 전 기부단체 리스트 조회 — 키워드 검색 + 페이징 + 정렬
     @GetMapping("/applications")
     public ResponseEntity<Page<FoundationListResponseDTO>> getApplicationList(

--- a/src/main/java/com/merge/final_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/merge/final_project/global/config/SecurityConfig.java
@@ -145,6 +145,8 @@ public class SecurityConfig {
                                 "/api/foundation/logout",    // 로그아웃 (토큰 만료 후에도 호출 가능해야 함)
                                 "/api/foundation/campaigns"  // 캠페인 목록 조회 (공개)
                         ).permitAll()
+                        // GET 한정 공개 — 일반 사용자 기부단체 상세 조회 (숫자 ID 경로만 허용, /me 등 제외)
+                        .requestMatchers(HttpMethod.GET, "/api/foundation/{foundationNo:\\d+}").permitAll()
                         // GET 한정 공개 — POST /register는 ROLE_FOUNDATION 필요
                         .requestMatchers(HttpMethod.GET, "/api/foundation/campaigns/*").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/foundation/campaigns/*/detail").permitAll()

--- a/src/main/java/com/merge/final_project/org/FoundationController.java
+++ b/src/main/java/com/merge/final_project/org/FoundationController.java
@@ -46,10 +46,10 @@ public class FoundationController {
         return ResponseEntity.ok(foundationService.getPublicFoundationList(keyword, pageable));
     }
 
-    // 기부단체 상세 조회
+    // 기부단체 상세 조회 (일반 사용자 공개 — ACTIVE 단체만, 민감 정보 제외)
     @GetMapping("/{foundationNo}")
-    public ResponseEntity<FoundationDetailResponseDTO> getDetail(@PathVariable Long foundationNo) {
-        return ResponseEntity.ok(foundationService.getFoundationDetail(foundationNo));
+    public ResponseEntity<FoundationPublicDetailDTO> getDetail(@PathVariable Long foundationNo) {
+        return ResponseEntity.ok(foundationService.getPublicFoundationDetail(foundationNo));
     }
 
     // 기부단체 로그인
@@ -63,6 +63,13 @@ public class FoundationController {
     public ResponseEntity<Void> logout(@RequestHeader("Authorization") String bearerToken) {
         foundationService.logout(bearerToken);
         return ResponseEntity.ok().build();
+    }
+
+    // 기부단체 본인 상세 정보 조회 (마이페이지 / 회원정보 수정 화면 진입 시)
+    @GetMapping("/me")
+    public ResponseEntity<FoundationDetailResponseDTO> getMyDetail(Authentication authentication) {
+        Long foundationNo = (Long) authentication.getDetails();
+        return ResponseEntity.ok(foundationService.getFoundationDetail(foundationNo));
     }
 
     // 기부단체 회원정보 수정 (설명, 연락처, 계좌, 은행명, 수수료율, 프로필 이미지)

--- a/src/main/java/com/merge/final_project/org/FoundationService.java
+++ b/src/main/java/com/merge/final_project/org/FoundationService.java
@@ -31,6 +31,9 @@ public interface FoundationService {
     //공개 단체 목록 — 키워드 검색 추가 (여기는 상태가 승인된 애들만 공개 됨)
     Page<FoundationListResponseDTO> getPublicFoundationList(String keyword, Pageable pageable);
 
+    // 일반 사용자용 기부단체 상세 조회 — ACTIVE 단체만, 민감 정보 제외
+    FoundationPublicDetailDTO getPublicFoundationDetail(Long foundationNo);
+
     //관리자 승인 단체 목록 — 상태 필터 + 키워드 검색 + 페이징
     Page<FoundationListResponseDTO> getApprovedFoundationListForAdmin(AccountStatus accountStatus, String keyword, Pageable pageable);
     FoundationDetailResponseDTO getFoundationDetail(Long foundationNo);

--- a/src/main/java/com/merge/final_project/org/FoundationServiceImpl.java
+++ b/src/main/java/com/merge/final_project/org/FoundationServiceImpl.java
@@ -322,6 +322,18 @@ public class  FoundationServiceImpl implements FoundationService {
         return FoundationDetailResponseDTO.from(foundation);
     }
 
+    // 일반 사용자용 기부단체 상세 조회 — ACTIVE 단체만, 민감 정보 제외
+    @Override
+    @Transactional(readOnly = true)
+    public FoundationPublicDetailDTO getPublicFoundationDetail(Long foundationNo) {
+        Foundation foundation = foundationRepository.findById(foundationNo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.FOUNDATION_NOT_FOUND));
+        if (foundation.getAccountStatus() != AccountStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.FOUNDATION_NOT_FOUND);
+        }
+        return FoundationPublicDetailDTO.from(foundation);
+    }
+
     // 기부단체 승인 시 임시 비밀번호 생성 후 메일 보내는 메서드 비동기로 호출,
     @Transactional
     @Override

--- a/src/main/java/com/merge/final_project/org/dto/FoundationPublicDetailDTO.java
+++ b/src/main/java/com/merge/final_project/org/dto/FoundationPublicDetailDTO.java
@@ -1,0 +1,44 @@
+package com.merge.final_project.org.dto;
+
+import com.merge.final_project.org.Foundation;
+import com.merge.final_project.org.FoundationType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class FoundationPublicDetailDTO {
+
+    private Long foundationNo;
+    private String foundationName;
+    private String representativeName;
+    private FoundationType foundationType;
+    private String businessRegistrationNumber;
+    private String contactPhone;
+    private String description;
+    private String profilePath;
+    private BigDecimal feeRate;
+    private String bankName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static FoundationPublicDetailDTO from(Foundation foundation) {
+        return FoundationPublicDetailDTO.builder()
+                .foundationNo(foundation.getFoundationNo())
+                .foundationName(foundation.getFoundationName())
+                .representativeName(foundation.getRepresentativeName())
+                .foundationType(foundation.getFoundationType())
+                .businessRegistrationNumber(foundation.getBusinessRegistrationNumber())
+                .contactPhone(foundation.getContactPhone())
+                .description(foundation.getDescription())
+                .profilePath(foundation.getProfilePath())
+                .feeRate(foundation.getFeeRate())
+                .bankName(foundation.getBankName())
+                .createdAt(foundation.getCreatedAt())
+                .updatedAt(foundation.getUpdatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 작업 개요
기부단체 상세 페이지가 개인 정보 관련된 부분도 공개되었기에 사용자 공개용, 관리자 공개용, 기부단체 용으로 분리하였습니다. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공개 재단 정보 상세 조회 기능 추가 (로그인 불필요)
  * 인증된 재단 사용자를 위한 "나의 재단" 상세 정보 조회 기능 추가
  * 관리자용 재단 상세 정보 조회 기능 추가
  * 공개용 재단 정보 데이터 구조 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->